### PR TITLE
fix lib error and file not found error

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -4,6 +4,9 @@ FROM python:${VERSION:-3.11}
 
 WORKDIR /app
 
+RUN mkdir downloads \
+    && mkdir uploads
+
 COPY requirements.txt .
 
 COPY scripts/nltk_download.sh ./scripts/nltk_download.sh

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -56,3 +56,4 @@ qdrant-client[fastembed]
 polars==1.17.1
 fastexcel==0.12.0
 thefuzz==0.22.1
+boto3==1.35.32


### PR DESCRIPTION
- Add boto3 to requirements.txt for supporting AWS S3.
- Update backend's Dockerfile to create downloads folder for storing downloaded files.